### PR TITLE
Fix `owner` reference not normally exported from `VirtualFileSystem.selectUser`

### DIFF
--- a/virtualfilesystem.go
+++ b/virtualfilesystem.go
@@ -39,9 +39,9 @@ type FolderOptions struct {
 }
 
 func (fs *VirtualFileSystem) selectUser(userName string) (*User, error) {
-	for _, owner := range fs.owners {
+	for i, owner := range fs.owners {
 		if owner.name == userName {
-			return &owner, nil
+			return &fs.owners[i], nil
 		}
 	}
 	return nil, fmt.Errorf("Error: The [%s] doesn't exist\n", userName)


### PR DESCRIPTION
Since golang actually copy the value before entering a for... loop with `range`, we can not use the reference from the `range` as the final exported reference, because it is Not the origin reference.

However, we can use array index to know which position is our target, so we save that index, and finally return the origin reference with that index.

Please refer to this issue for more detail: https://github.com/golang/go/issues/20733